### PR TITLE
fix: use temp file to execute k8s definition

### DIFF
--- a/pykubectl/kubectl.py
+++ b/pykubectl/kubectl.py
@@ -16,7 +16,7 @@ class KubeCtl:
             if definition:
                 temp_file.write(definition)
                 temp_file.flush()
-                cmd = f'{cmd} -f {temp_file.name}' \
+                cmd = f'{cmd} -f {temp_file.name}'
 
             logging.debug(f'executing {cmd}')
 

--- a/pykubectl/kubectl.py
+++ b/pykubectl/kubectl.py
@@ -35,7 +35,6 @@ class KubeCtl:
 
     def get(self, *args, **kwargs):
         result = self.execute('get -o json', *args, **kwargs).decode()
-        print(f"result is: {json.loads(result)}")
         return json.loads(result)
 
     def describe(self, *args, **kwargs):

--- a/pykubectl/kubectl.py
+++ b/pykubectl/kubectl.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import tempfile
 from subprocess import CalledProcessError, check_output
 
 
@@ -11,19 +12,20 @@ class KubeCtl:
     def execute(self, command, definition=None, safe=False):
         cmd = f'{self.kubectl} {command}'
 
-        if definition:
-            cmd = f'cat <<EOF | {cmd} -f -\n' \
-                  f'{definition}\n' \
-                  f'EOF'
+        with tempfile.NamedTemporaryFile('w') as temp_file:
+            if definition:
+                temp_file.write(definition)
+                temp_file.flush()
+                cmd = f'{cmd} -f {temp_file.name}' \
 
-        logging.debug(f'executing {cmd}')
+            logging.debug(f'executing {cmd}')
 
-        try:
-            return check_output(cmd, shell=True)
-        except CalledProcessError as e:
-            if not safe:
-                raise e
-            logging.warn(f'Command {command} failed, swallowing')
+            try:
+                return check_output(cmd, shell=True)
+            except CalledProcessError as e:
+                if not safe:
+                    raise e
+                logging.warn(f'Command {command} failed, swallowing')
 
     def apply(self, *args, **kwargs):
         return self.execute('apply', *args, **kwargs)
@@ -33,7 +35,8 @@ class KubeCtl:
 
     def get(self, *args, **kwargs):
         result = self.execute('get -o json', *args, **kwargs).decode()
-        return json.loads(result)['items']
+        print(f"result is: {json.loads(result)}")
+        return json.loads(result)
 
     def describe(self, *args, **kwargs):
         return self.execute('describe', *args, **kwargs)

--- a/pykubectl/kubectl.py
+++ b/pykubectl/kubectl.py
@@ -3,26 +3,27 @@ import logging
 from subprocess import CalledProcessError, check_output
 
 
-class KubeCtl(object):
+class KubeCtl:
     def __init__(self, bin='kubectl', global_flags=''):
-        super(KubeCtl, self).__init__()
-        self.kubectl = '{} {}'.format(bin, global_flags)
+        super().__init__()
+        self.kubectl = f'{bin} {global_flags}'
 
     def execute(self, command, definition=None, safe=False):
-        cmd = '{} {}'.format(self.kubectl, command)
+        cmd = f'{self.kubectl} {command}'
 
         if definition:
-            pre = 'echo \'{}\''.format(definition)
-            cmd = '{} | {} -f -'.format(pre, cmd)
+            cmd = f'cat <<EOF | {cmd} -f -\n' \
+                  f'{definition}\n' \
+                  f'EOF'
 
-        logging.debug('executing {}'.format(cmd))
+        logging.debug(f'executing {cmd}')
 
         try:
             return check_output(cmd, shell=True)
         except CalledProcessError as e:
             if not safe:
                 raise e
-            logging.warn('Command {} failed, swallowing'.format(command))
+            logging.warn(f'Command {command} failed, swallowing')
 
     def apply(self, *args, **kwargs):
         return self.execute('apply', *args, **kwargs)

--- a/pykubectl/objects.py
+++ b/pykubectl/objects.py
@@ -9,7 +9,7 @@ from .utils import render_definition
 from .yaml_utils import Loader
 
 
-class KubeObject(object):
+class KubeObject:
     kind = ""
 
     @property
@@ -32,13 +32,13 @@ class KubeObject(object):
         return self
 
     def __repr__(self):
-        return "{kind}[{name}]".format(kind=self.kind, name=self.name)
+        return f"{self.kind}[{self.name}]"
 
     def __str__(self):
         return self.__repr__()
 
     def __init__(self, definition, kubectl):
-        super(KubeObject, self).__init__()
+        super().__init__()
         self.definition = definition
         self.kubectl = kubectl
 
@@ -47,7 +47,7 @@ class KubeObject(object):
         if not self.kind:
             self.kind = kind
         elif kind != self.kind:
-            raise KubernetesException("Invalid kind {} provided".format(kind))
+            raise KubernetesException(f"Invalid kind {kind} provided")
 
         self.name = self.definition["metadata"]["name"]
 
@@ -71,7 +71,7 @@ class Deployment(KubeObject):
 
     def undo(self, *args, **kwargs):
         logging.warn("%s: rolling back last deployment", self)
-        cmd = "rollout undo deployment/{}".format(self.name)
+        cmd = f"rollout undo deployment/{self.name}"
         self.kubectl.execute(cmd, *args, **kwargs)
 
     def deploy(self, attempts=30):
@@ -92,7 +92,7 @@ class Deployment(KubeObject):
             attempts -= 1
 
         self.undo(safe=True)
-        raise KubernetesException("deployment of {} timed out".format(self))
+        raise KubernetesException(f"deployment of {self} timed out")
 
     def execute_pod(self, name, override_command=None, **extra_overrides):
         spec = copy.deepcopy(self.definition["spec"]["template"]["spec"])
@@ -109,7 +109,7 @@ class Deployment(KubeObject):
             "kind": "Pod",
             "spec": spec,
             "metadata": {
-                "name": "{}-{}-{}".format(self.name, name, id),
+                "name": f"{self.name}-{name}-{id}",
             },
         }
 
@@ -128,7 +128,7 @@ class Pod(KubeObject):
         while attempts >= 0:
             phase = self.get()["status"]["phase"]
             if phase == "Failed":
-                raise KubernetesException("{} execution failed".format(self))
+                raise KubernetesException(f"{self} execution failed")
             if phase == "Succeeded":
                 logging.info("successfully completed")
                 return
@@ -138,8 +138,8 @@ class Pod(KubeObject):
             sleep(10)
             attempts -= 1
 
-        raise KubernetesException("{} execution timed out".format(self))
+        raise KubernetesException(f"{self} execution timed out")
 
     def logs(self, *args, **kwargs):
-        cmd = "logs {}".format(self.name)
+        cmd = f"logs {self.name}"
         return self.kubectl.execute(cmd, *args, **kwargs)

--- a/pykubectl/objects.py
+++ b/pykubectl/objects.py
@@ -52,7 +52,7 @@ class KubeObject:
         self.name = self.definition["metadata"]["name"]
 
     def get(self, *args, **kwargs):
-        return self.kubectl.get(self.raw, *args, **kwargs)[0]
+        return self.kubectl.get(self.raw, *args, **kwargs)
 
     def delete(self, *args, **kwargs):
         logging.info("%s: deleting", self)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def system(command):
 
 setup(
     name="PyKubeCtl",
-    version='0.2.0',
+    version='0.3.0',
     description="A python bridge to kubectl",
     url='https://github.com/4Catalyzer/pykubectl',
     author="Giacomo Tagliabue",
@@ -35,7 +35,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
     ),
     keywords='kubernetes docker ci cd',


### PR DESCRIPTION
Should fix this error I think:
`error: error parsing STDIN: json: line 1: invalid character '\n' in string literal`
that occurs at: https://github.com/4Catalyzer/pykubectl/blob/ed6a1cdbf3f6ab964bbe9b651ec5acb1a77306c4/pykubectl/kubectl.py#L21

(this seems to be a bit more resilient to special characters)

Tested locally in dependent service via:
`pip install -e ../../../4catalyzer/pykubectl`