### PR TITLE
feat: add validate flag to apply command

### DIFF
--- a/pykubectl/kubectl.py
+++ b/pykubectl/kubectl.py
@@ -9,7 +9,7 @@ class KubeCtl:
         super().__init__()
         self.kubectl = f'{bin} {global_flags}'
 
-    def execute(self, command, definition=None, safe=False):
+    def execute(self, command, definition=None, safe=False, validate=False):
         cmd = f'{self.kubectl} {command}'
 
         with tempfile.NamedTemporaryFile('w') as temp_file:
@@ -19,6 +19,9 @@ class KubeCtl:
                 cmd = f'{cmd} -f {temp_file.name}'
 
             logging.debug(f'executing {cmd}')
+
+            if validate:
+                cmd = f"{cmd} --dry-run --validate"
 
             try:
                 return check_output(cmd, shell=True)

--- a/pykubectl/kubectl.py
+++ b/pykubectl/kubectl.py
@@ -21,7 +21,7 @@ class KubeCtl:
             logging.debug(f'executing {cmd}')
 
             if validate:
-                cmd = f"{cmd} --dry-run --validate"
+                cmd = f"{cmd} --dry-run=client --validate"
 
             try:
                 return check_output(cmd, shell=True)


### PR DESCRIPTION
Adds the "--validate" option to the `kubectl` `apply` command

We can add this option to CI to validate configurations before the actual deploy step